### PR TITLE
v0.7.1

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: gphoto2
-version: 0.7.0
+version: 0.7.1
 
 authors:
   - Sijawusz Pur Rahnama <sija@sija.pl>

--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,7 @@ version: 0.7.0
 authors:
   - Sijawusz Pur Rahnama <sija@sija.pl>
 
-crystal: 0.19.4
+crystal: 0.21.0
 
 libraries:
   libgphoto2: ~> 2.5.2

--- a/spec/gphoto2/version_spec.cr
+++ b/spec/gphoto2/version_spec.cr
@@ -1,0 +1,13 @@
+require "yaml"
+require "../spec_helper"
+
+describe GPhoto2::VERSION do
+  it "should have proper format" do
+    GPhoto2::VERSION.should match /^\d+(\.\d+){2,3}(-\w+)?$/
+  end
+
+  it "should match shard.yml" do
+    version = YAML.parse(File.read(File.join(__DIR__, "../..", "shard.yml")))["version"].as_s
+    version.should eq GPhoto2::VERSION
+  end
+end

--- a/spec/gphoto2_spec.cr
+++ b/spec/gphoto2_spec.cr
@@ -1,24 +1,11 @@
 require "./spec_helper"
-require "yaml"
 
-VERSION_PATTERN = /^\d+(\.\d+){2,3}(-\w+)?$/
-ENV_DEBUG_KEY   = "DEBUG"
+ENV_DEBUG_KEY = "DEBUG"
 
 describe GPhoto2 do
-  describe "VERSION" do
-    it "should have proper format" do
-      GPhoto2::VERSION.should match VERSION_PATTERN
-    end
-
-    it "should match shard.yml" do
-      version = YAML.parse(File.read(File.join(__DIR__, "..", "shard.yml")))["version"].as_s
-      version.should eq GPhoto2::VERSION
-    end
-  end
-
   describe ".library_version" do
     it "should have proper format" do
-      GPhoto2.library_version.should match VERSION_PATTERN
+      GPhoto2.library_version.should match /^\d+(\.\d+){2,3}(-\w+)?$/
     end
   end
 

--- a/src/gphoto2/camera.cr
+++ b/src/gphoto2/camera.cr
@@ -14,10 +14,6 @@ module GPhoto2
     getter model : String
     getter port : String
 
-    @context : Context?
-    @abilities : CameraAbilities?
-    @port_info : PortInfo?
-
     protected setter abilities : CameraAbilities?
     protected setter port_info : PortInfo?
 

--- a/src/gphoto2/camera/configuration.cr
+++ b/src/gphoto2/camera/configuration.cr
@@ -1,8 +1,6 @@
 module GPhoto2
   class Camera
     module Configuration
-      @dirty : Bool = false
-
       # Returns camera `CameraWidget::Window` root configuration widget.
       getter window : CameraWidget::Window { get_config.as(CameraWidget::Window) }
 
@@ -177,7 +175,7 @@ module GPhoto2
       # camera[:iso] = 400
       # camera.dirty? # => true
       # ```
-      getter? :dirty
+      getter? dirty = false
 
       private def reset : Void
         @window = nil

--- a/src/gphoto2/camera/event.cr
+++ b/src/gphoto2/camera/event.cr
@@ -27,7 +27,7 @@ module GPhoto2
             CameraFile.new(self, path.folder, path.name)
           when .folder_added?
             path = CameraFilePath.new(data_ptr.as(LibGPhoto2::CameraFilePath*))
-            CameraFolder.new(self, File.join(path.folder, path.name))
+            CameraFolder.new(self, CameraFile.join(path.folder, path.name))
           when .unknown?
             data_ptr.null? ? nil : String.new(data_ptr.as(LibC::Char*))
           else

--- a/src/gphoto2/camera/filesystem.cr
+++ b/src/gphoto2/camera/filesystem.cr
@@ -17,6 +17,14 @@ module GPhoto2
       def /(path) : CameraFolder
         filesystem(path)
       end
+
+      # Clear the filesystem.
+      #
+      # Resets the filesystem. All cached information including the folder tree
+      # will get lost and will be queried again on demand.
+      def filesystem_reset : Void
+        context.check! LibGPhoto2.gp_filesystem_reset(wrapped.fs)
+      end
     end
   end
 end

--- a/src/gphoto2/camera_abilities_list.cr
+++ b/src/gphoto2/camera_abilities_list.cr
@@ -4,9 +4,6 @@ module GPhoto2
   class CameraAbilitiesList
     include Struct(LibGPhoto2::CameraAbilitiesList)
 
-    @context : Context
-    @port_info_list : PortInfoList
-
     def initialize(@context : Context, @port_info_list : PortInfoList = PortInfoList.new)
       new
       load

--- a/src/gphoto2/camera_file.cr
+++ b/src/gphoto2/camera_file.cr
@@ -134,7 +134,7 @@ module GPhoto2
 
     private def _read(type = LibGPhoto2::CameraFileType::Normal)
       buffer = Bytes.new(BUFFER_SIZE)
-      offset, size = _read(buffer, 0, type)
+      offset, size = _read(buffer, 0_u64, type)
 
       data = Pointer(UInt8).malloc(size)
       data.copy_from(buffer.to_unsafe, size)

--- a/src/gphoto2/camera_file.cr
+++ b/src/gphoto2/camera_file.cr
@@ -18,6 +18,13 @@ module GPhoto2
 
     protected delegate :context, to: @camera
 
+    # Returns a new string formed by joining the strings using `/`.
+    #
+    # NOTE: OS-independent substitute of `File.join` applicable to *libgphoto2* fs.
+    def self.join(*args : String) : String
+      args.join '/', &.chomp('/')
+    end
+
     def initialize(@camera : Camera, @folder : String? = nil, @name : String? = nil)
       new
     end
@@ -80,7 +87,7 @@ module GPhoto2
 
     # Returns full file path (within the camera filesystem).
     def path : String
-      File.join folder, name
+      self.class.join folder, name
     end
 
     def_equals @camera, @folder, @name

--- a/src/gphoto2/camera_file.cr
+++ b/src/gphoto2/camera_file.cr
@@ -10,12 +10,10 @@ module GPhoto2
     # Initial buffer size used in `#read`.
     BUFFER_SIZE = 256 * 1024
 
-    @camera : Camera
-    @data_and_size : {UInt8*, LibC::ULong}?
-
     getter! folder : String
     getter! name : String
 
+    protected getter camera : Camera
     protected delegate :context, to: @camera
 
     # Returns a new string formed by joining the strings using `/`.
@@ -106,11 +104,9 @@ module GPhoto2
       preview? ? PREVIEW_FILENAME : name
     end
 
-    private def data_and_size
-      @data_and_size ||= begin
-        get unless preview?
-        get_data_and_size
-      end
+    private getter data_and_size : {UInt8*, LibC::ULong} do
+      get unless preview?
+      get_data_and_size
     end
 
     private def get_data_and_size

--- a/src/gphoto2/camera_folder.cr
+++ b/src/gphoto2/camera_folder.cr
@@ -36,7 +36,7 @@ module GPhoto2
       when "."
         self
       else
-        self.class.new(@camera, File.join(@path, name))
+        self.class.new(@camera, CameraFile.join(@path, name))
       end
     end
 

--- a/src/gphoto2/camera_widgets/range.cr
+++ b/src/gphoto2/camera_widgets/range.cr
@@ -5,7 +5,7 @@ module GPhoto2
     class Range < Base
       def range : Array(LibC::Float)
         min, max, inc = get_range
-        min.step(by: inc, limit: max).to_a
+        min.step(to: max, by: inc).to_a
       end
 
       private def get_range

--- a/src/gphoto2/context/callbacks.cr
+++ b/src/gphoto2/context/callbacks.cr
@@ -81,7 +81,8 @@ module GPhoto2
         if GPhoto2.check?(rc)
           return rc
         else
-          message = @last_error || GPhoto2.result_as_string(rc)
+          message, @last_error = @last_error, nil
+          message ||= GPhoto2.result_as_string(rc)
           raise Error.new(message, rc)
         end
       end

--- a/src/gphoto2/entry.cr
+++ b/src/gphoto2/entry.cr
@@ -1,8 +1,5 @@
 module GPhoto2
   class Entry
-    @camera_list : CameraList
-    @index : Int32
-
     def initialize(@camera_list : CameraList, @index : Int32); end
 
     def name : String

--- a/src/gphoto2/version.cr
+++ b/src/gphoto2/version.cr
@@ -1,3 +1,3 @@
 module GPhoto2
-  VERSION = "0.7.0"
+  VERSION = "0.7.1"
 end

--- a/src/lib/gphoto2/camera.cr
+++ b/src/lib/gphoto2/camera.cr
@@ -1,3 +1,4 @@
+require "./camera_filesystem"
 require "./camera_file"
 
 @[Link("libgphoto2")]
@@ -112,9 +113,6 @@ lib LibGPhoto2
   struct CameraText
     text : LibC::Char[32768] # 32 * 1024
   end
-
-  # TODO?
-  alias CameraFilesystem = Void*
 
   struct CameraFunctions
     pre_func : CameraPrePostFunc

--- a/src/lib/gphoto2/camera.cr
+++ b/src/lib/gphoto2/camera.cr
@@ -55,8 +55,8 @@ lib LibGPhoto2
   # Aliases
   #
 
-  alias CameraPrivateLibrary      = Void*
-  alias CameraPrivateCore         = Void*
+  alias CameraPrivateLibrary      = Void
+  alias CameraPrivateCore         = Void
 
   alias CameraGetConfigFunc       = Camera*, CameraWidget**, GPContext* -> LibC::Int
   alias CameraSetConfigFunc       = Camera*, CameraWidget*, GPContext* -> LibC::Int

--- a/src/lib/gphoto2/camera_filesystem.cr
+++ b/src/lib/gphoto2/camera_filesystem.cr
@@ -1,0 +1,79 @@
+require "./camera_file_info"
+require "./camera_file"
+
+@[Link("libgphoto2")]
+lib LibGPhoto2
+  #
+  # Aliases
+  #
+
+  # TODO?
+  alias CameraStorageInformation = Void
+
+  alias CameraFilesystemListFunc        = CameraFilesystem*, LibC::Char*, CameraList*, Void*, GPContext* -> LibC::Int
+  alias CameraFilesystemSetInfoFunc     = CameraFilesystem*, LibC::Char*, LibC::Char*, CameraFileInfo, Void*, GPContext* -> LibC::Int
+  alias CameraFilesystemGetInfoFunc     = CameraFilesystem*, LibC::Char*, LibC::Char*, CameraFileInfo, Void*, GPContext* -> LibC::Int
+  alias CameraFilesystemGetFileFunc     = CameraFilesystem*, LibC::Char*, LibC::Char*, CameraFileType, CameraFile*, Void*, GPContext* -> LibC::Int
+  alias CameraFilesystemReadFileFunc    = CameraFilesystem*, LibC::Char*, LibC::Char*, CameraFileType, LibC::UInt64T, LibC::Char*, LibC::UInt64T, Void*, GPContext* -> LibC::Int
+  alias CameraFilesystemDeleteFileFunc  = CameraFilesystem*, LibC::Char*, LibC::Char*, Void*, GPContext* -> LibC::Int
+  alias CameraFilesystemPutFileFunc     = CameraFilesystem*, LibC::Char*, LibC::Char*, CameraFileType, CameraFile*, Void*, GPContext* -> LibC::Int
+  alias CameraFilesystemDeleteAllFunc   = CameraFilesystem*, LibC::Char*, Void*, GPContext* -> LibC::Int
+  alias CameraFilesystemDirFunc         = CameraFilesystem*, LibC::Char*, LibC::Char*, Void*, GPContext* -> LibC::Int
+  alias CameraFilesystemStorageInfoFunc = CameraFilesystem*, CameraStorageInformation**, LibC::Int, Void*, GPContext* -> LibC::Int
+
+  #
+  # Structs
+  #
+
+  struct CameraFilesystemFile
+    name : LibC::Char*
+    info_dirty : LibC::Int
+    info : CameraFileInfo
+    lru_prev : CameraFilesystemFile*
+    lru_next : CameraFilesystemFile*
+    preview : CameraFile*
+    normal : CameraFile*
+    raw : CameraFile*
+    audio : CameraFile*
+    exif : CameraFile*
+    metadata : CameraFile*
+    next : CameraFilesystemFile*
+  end
+
+  struct CameraFilesystemFolder
+    name : LibC::Char*
+    files_dirty : LibC::Int
+    folders_dirty : LibC::Int
+    next : CameraFilesystemFolder*
+    folders : CameraFilesystemFolder*
+    files : CameraFilesystemFile*
+  end
+
+  struct CameraFilesystem
+    rootfolder : CameraFilesystemFolder*
+    lru_first : CameraFilesystemFile*
+    lru_last : CameraFilesystemFile*
+    lru_size : LibC::UInt
+    get_info_func : CameraFilesystemGetInfoFunc
+    set_info_func : CameraFilesystemSetInfoFunc
+    file_list_func : CameraFilesystemListFunc
+    folder_list_func : CameraFilesystemListFunc
+    get_file_func : CameraFilesystemGetFileFunc
+    read_file_func : CameraFilesystemReadFileFunc
+    delete_file_func : CameraFilesystemDeleteFileFunc
+    put_file_func : CameraFilesystemPutFileFunc
+    delete_all_func : CameraFilesystemDeleteAllFunc
+    make_dir_func : CameraFilesystemDirFunc
+    remove_dir_func : CameraFilesystemDirFunc
+    storage_info_func : CameraFilesystemStorageInfoFunc
+    data : Void*
+  end
+
+  #
+  # Functions
+  #
+
+  fun gp_filesystem_new(fs : CameraFilesystem*) : LibC::Int
+  fun gp_filesystem_free(fs : CameraFilesystem*) : LibC::Int
+  fun gp_filesystem_reset(fs : CameraFilesystem*) : LibC::Int
+end

--- a/src/lib/gphoto2_port.cr
+++ b/src/lib/gphoto2_port.cr
@@ -41,8 +41,8 @@ lib LibGPhoto2Port
   # Aliases
   #
 
-  alias GPPortPrivateLibrary = Void*
-  alias GPPortPrivateCore = Void*
+  alias GPPortPrivateLibrary = Void
+  alias GPPortPrivateCore = Void
 
   #
   # Structs
@@ -87,8 +87,8 @@ lib LibGPhoto2Port
     settings : GPPortSettings
     settings_pending : GPPortSettings
     timeout : LibC::Int
-    pl : GPPortPrivateLibrary
-    pc : GPPortPrivateCore
+    pl : GPPortPrivateLibrary*
+    pc : GPPortPrivateCore*
   end
 
   #


### PR DESCRIPTION
- New `CameraFile#join` for creating os-independent paths
- New `Camera#filesystem_reset` for clearing *libgphoto2* fs cache
- Resets `Context#last_error` after raising exception
- Minimal supported Crystal version is now `v0.21.0`
- Several fixes and refactors, as usual